### PR TITLE
fix: use correct privval path from Pell config

### DIFF
--- a/pelldvs/node.go
+++ b/pelldvs/node.go
@@ -54,7 +54,7 @@ func NewNode(
 	}
 
 	// Load or generate private validator
-	pv, err := privval.LoadOrGenFilePV(n.nodeCfg.PrivValidatorKeyFile())
+	pv, err := privval.LoadOrGenFilePV(n.nodeCfg.Pell.OperatorBLSPrivateKeyStorePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load or gen file PV: %v", err)
 	}


### PR DESCRIPTION
fix: use correct privval path from Pell config

Before pelldvs v0.3.0, the privval didn’t actually work, so it used the wrong BLS key path.
